### PR TITLE
Fix: return value from JSON data in `_get_value()` in API client subclasses

### DIFF
--- a/samanthas_telegram_bot/api_clients/backend/backend_client.py
+++ b/samanthas_telegram_bot/api_clients/backend/backend_client.py
@@ -127,7 +127,7 @@ class BackendClient(BaseApiClient):
         level: str = cls._get_value(data, "resulting_level")
         if level not in ALL_LEVELS:
             raise BackendClientError(
-                f"Received {level=} from the backend that does not match any accepted level"
+                f"Received {level=} from backend that does not match any accepted level. {data=}"
             )
 
         await logs(text=f"{level=}", bot=context.bot, update=update, level=LoggingLevel.INFO)
@@ -367,6 +367,6 @@ class BackendClient(BaseApiClient):
     @classmethod
     def _get_value(cls, data: DataDict, key: str) -> typing.Any:
         try:
-            super()._get_value(data, key)
+            return super()._get_value(data, key)
         except BaseApiClientError as err:
             raise BackendClientError("Failed to process data received from backend") from err

--- a/samanthas_telegram_bot/api_clients/smalltalk/smalltalk_client.py
+++ b/samanthas_telegram_bot/api_clients/smalltalk/smalltalk_client.py
@@ -267,6 +267,6 @@ class SmallTalkClient(BaseApiClient):
     @classmethod
     def _get_value(cls, data: DataDict, key: str) -> typing.Any:
         try:
-            super()._get_value(data, key)
+            return super()._get_value(data, key)
         except BaseApiClientError as err:
-            raise SmallTalkJSONParsingError("Could not parse data from SmallTalk") from err
+            raise SmallTalkJSONParsingError(f"Could not parse SmallTalk {data=}") from err


### PR DESCRIPTION
Changes introduced in #45 created a base API client and two subclasses. They call parent `._get_value()` method but don't return anything 🤦🏻 .

( Commit title is wrong :) )